### PR TITLE
Refactor `ClickViewReportStream` to initialize `date` attribute

### DIFF
--- a/tap_googleads/dynamic_streams/click_view_report.py
+++ b/tap_googleads/dynamic_streams/click_view_report.py
@@ -16,7 +16,12 @@ if TYPE_CHECKING:
 class ClickViewReportStream(DynamicQueryStream):
     """Stream for click view reports."""
     
-    date: datetime.date
+    # date: datetime.date
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.date: datetime.date | None = None
 
     @property
     def gaql(self):


### PR DESCRIPTION
- Add `__init__` method to initialize `date` as optional.
- Comment out the unused `date` type annotation.