### PR TITLE
Update date range logic and streamline `ClickViewReportStream` initia…

### DIFF
--- a/tap_googleads/dynamic_streams/click_view_report.py
+++ b/tap_googleads/dynamic_streams/click_view_report.py
@@ -16,11 +16,7 @@ if TYPE_CHECKING:
 class ClickViewReportStream(DynamicQueryStream):
     """Stream for click view reports."""
     
-    # date: datetime.date
-
-    def __init__(self, *args, **kwargs) -> None:
-        self.date: datetime.date | None = None
-        super().__init__(*args, **kwargs)
+    date: datetime.date
 
     @property
     def gaql(self):
@@ -88,7 +84,7 @@ class ClickViewReportStream(DynamicQueryStream):
     def request_records(self, context):
         start_value = self.get_starting_replication_key_value(context)
 
-        start_date = datetime.date.fromisoformat(start_value)
+        start_date = datetime.date.fromisoformat(start_value) if start_value else self.start_date
         end_date = datetime.date.fromisoformat(self.config["end_date"])
 
         delta = end_date - start_date

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -72,7 +72,7 @@ class TapGoogleAds(Tap):
         secret=True,
     )
     _end_date = datetime.now(timezone.utc).date()
-    _start_date = _end_date - timedelta(days=90)
+    _start_date = _end_date - timedelta(days=7)
 
     # TODO: Add Descriptions
     config_jsonschema = th.PropertiesList(


### PR DESCRIPTION
…lization

- Reduce default date range in `tap.py` from 90 to 7 days.
- Simplify `ClickViewReportStream` to use a single `date` attribute.
- Add fallback logic for `start_date` in `request_records` method.