### PR TITLE
Fix `start_date` fallback in `ClickViewReportStream`

### DIFF
--- a/tap_googleads/dynamic_streams/click_view_report.py
+++ b/tap_googleads/dynamic_streams/click_view_report.py
@@ -84,7 +84,7 @@ class ClickViewReportStream(DynamicQueryStream):
     def request_records(self, context):
         start_value = self.get_starting_replication_key_value(context)
 
-        start_date = datetime.date.fromisoformat(start_value) if start_value else self.start_date
+        start_date = datetime.date.fromisoformat(start_value) if start_value else datetime.date.fromisoformat(self.config["start_date"])
         end_date = datetime.date.fromisoformat(self.config["end_date"])
 
         delta = end_date - start_date


### PR DESCRIPTION
- Update `request_records` method to fallback to `config["start_date"]` when `start_value` is missing.