### PR TITLE
Update start_date logic and reduce default date range

### DIFF
--- a/tap_googleads/dynamic_streams/click_view_report.py
+++ b/tap_googleads/dynamic_streams/click_view_report.py
@@ -84,7 +84,7 @@ class ClickViewReportStream(DynamicQueryStream):
     def request_records(self, context):
         start_value = self.get_starting_replication_key_value(context)
 
-        start_date = datetime.date.fromisoformat(start_value)
+        start_date = datetime.date.fromisoformat(start_value) if start_value else datetime.date.fromisoformat(self.config["start_date"])
         end_date = datetime.date.fromisoformat(self.config["end_date"])
 
         delta = end_date - start_date

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -72,7 +72,7 @@ class TapGoogleAds(Tap):
         secret=True,
     )
     _end_date = datetime.now(timezone.utc).date()
-    _start_date = _end_date - timedelta(days=90)
+    _start_date = _end_date - timedelta(days=7)
 
     # TODO: Add Descriptions
     config_jsonschema = th.PropertiesList(


### PR DESCRIPTION
- Adjust default `start_date` in `tap.py` to 7 days instead of 90.
- Fix `start_date` initialization in `click_view_report.py` to handle cases where the starting replication key is missing.