### PR TITLE
Fix `start_date` initialization in `click_view_report.py` constructor

### DIFF
--- a/tap_googleads/dynamic_streams/click_view_report.py
+++ b/tap_googleads/dynamic_streams/click_view_report.py
@@ -18,6 +18,10 @@ class ClickViewReportStream(DynamicQueryStream):
     
     date: datetime.date
 
+    def __init__(self, *args, **kwargs) -> None:
+        self.date = datetime.date.fromisoformat(self.config["start_date"])
+        super().__init__(*args, **kwargs)
+
     @property
     def gaql(self):
         return f"""


### PR DESCRIPTION
- Initialize `start_date` from configuration during `ClickViewReport` object instantiation.